### PR TITLE
Corregir campo de calificación en tabla últimos intentos

### DIFF
--- a/theme/spacechild/renderers/renderer-quiz.php
+++ b/theme/spacechild/renderers/renderer-quiz.php
@@ -325,6 +325,9 @@ class theme_spacechild_mod_quiz_renderer extends mod_quiz\output\renderer {
             $row[] = $estadisticas->aciertos;
             $row[] = $estadisticas->fallos;
             $row[] = $estadisticas->pendientes;
+
+            $flags = \core_course\external\course_media::get_flags_by_correct_questions($attemptobj->get_attempt()->id);
+
             if ($viewobj->markcolumn and false) {
                 if (
                     $attemptoptions->marks >= question_display_options::MARK_AND_MAX &&
@@ -337,7 +340,7 @@ class theme_spacechild_mod_quiz_renderer extends mod_quiz\output\renderer {
             }
 
             // Ouside the if because we may be showing feedback but not grades.
-            $attemptgrade = quiz_rescale_grade($attemptobj->get_sum_marks(), $quiz, false);
+            $attemptgrade = quiz_rescale_grade($attemptobj->get_sum_marks() - $flags, $quiz, false);
 
             if ($viewobj->gradecolumn) {
                 if (


### PR DESCRIPTION
## Descripción

- Se soluciono el error en el campo de **calificación** en la tabla **últimos intentos**.

## Resumen de los cambios

- Se hizo una consulta SQL con el fin de capturar la cantidad de banderas que tiene una pregunta en un determinado cuestionario.
- Se hizo un cálculo nuevo para mostrar la nota real.

## Checklist

- [x] Reemplazo de "**nota arriesgado**" por "**nota real**".

## Screensshots

![image](https://github.com/gerpollo2000/dfp/assets/116986434/f1856334-acdf-4d10-a4fa-eb84c378c589)

![image](https://github.com/gerpollo2000/dfp/assets/116986434/59d5b288-8f37-4bc7-a35f-c160dbb011a2)
